### PR TITLE
Correcting the property on rowData for distance

### DIFF
--- a/index.android.js
+++ b/index.android.js
@@ -103,7 +103,7 @@
            Proximity: {rowData.proximity ? rowData.proximity : 'NA'}
          </Text>
          <Text>
-           Distance: {rowData.accuracy ? rowData.accuracy.toFixed(2) : 'NA'}m
+           Distance: {rowData.distance ? rowData.distance.toFixed(2) : 'NA'}m
          </Text>
        </View>
      );


### PR DESCRIPTION
Issue: https://github.com/MacKentoch/reactNativeBeaconExample/issues/6

I was getting `undefined` for distance while using `rowData.accuracy` with Estimote Beacons on my android device.

It worked fine after I read through the entire object `rowData` and found `rowData.distance` as a valid property.